### PR TITLE
Request uri without entry file part

### DIFF
--- a/src/Voter/UriVoter.php
+++ b/src/Voter/UriVoter.php
@@ -18,6 +18,6 @@ class UriVoter extends RequestAwareVoter
      */
     public function match(Matchable $item): bool
     {
-        return $this->matches($this->getRequest()->getRequestUri(), $item);
+        return $this->matches($this->getRequest()->getPathInfo(), $item);
     }
 }


### PR DESCRIPTION
It will fix problem with app.php or app_dev.php in request URI. So RegexVoter can be used now without starting all regex with ^(/app_dev\\.php)? Same in case of PrefixVoter.